### PR TITLE
Glmap - Create an Activity mapping for GitLAb

### DIFF
--- a/src/api_manager.py
+++ b/src/api_manager.py
@@ -33,6 +33,8 @@ class APIManager:
 
         Returns:
             A list of dictionaries corresponding to the events of a contributor
+            The headers of the response
+
         """
         pass
 
@@ -43,12 +45,27 @@ class APIManager:
         """
         events = []
         for page in range(1, self.max_queries + 1):
-            new_events = self._query_event_page(contributor, page)
+            new_events, headers = self._query_event_page(contributor, page)
             events.extend(new_events)
 
-            if len(new_events) < 100:
+            if not self._check_events_left(new_events, headers):
                 break
         return events
+
+    # Function to check if there are events left
+    @abstractmethod
+    def _check_events_left(self, events, headers):
+        """
+        Abstract method to check if there are events left to query. Useful to adapt to the API used.
+
+        Parameters:
+            events: A list of dictionaries corresponding to the events of a contributor
+            headers: The headers of the response
+
+        Returns:
+            True if there are events left, False otherwise
+        """
+        pass
 
     @staticmethod
     def wait_reset(reset_time):

--- a/src/api_manager.py
+++ b/src/api_manager.py
@@ -1,4 +1,6 @@
+import time
 from abc import abstractmethod
+from datetime import datetime
 
 import numpy as np
 import pandas as pd
@@ -45,9 +47,22 @@ class APIManager:
             events.extend(new_events)
 
             if len(new_events) < 100:
-
                 break
         return events
+
+    @staticmethod
+    def wait_reset(reset_time):
+        """
+        Wait until the reset time of the API.
+
+        Parameters:
+            reset_time: The reset time of the API in the format '%Y-%m-%d %H:%M:%S'
+        """
+        # TODO: Check if we need a reset overhead time like in rabbit.
+        reset_time = datetime.strptime(reset_time, '%Y-%m-%d %H:%M:%S')
+        time_diff = (reset_time - datetime.now()).total_seconds()
+        print(f"Waiting for {time_diff} seconds until the reset time.")
+        time.sleep(time_diff)
 
     @abstractmethod
     def events_to_activities(self, events):

--- a/src/api_manager.py
+++ b/src/api_manager.py
@@ -15,11 +15,13 @@ class APIManager:
     Attributes:
         api_key: The API key to use the API
         max_queries: The maximum number of pages to query
+        min_events: The minimum number of events to query
     """
 
-    def __init__(self, api_key, max_queries=3):
+    def __init__(self, api_key, max_queries=3, min_events=5):
         self.api_key = api_key
         self.max_queries = max_queries
+        self.min_events = min_events
 
     @abstractmethod
     def _query_event_page(self, contributor, page):
@@ -46,7 +48,6 @@ class APIManager:
         for page in range(1, self.max_queries + 1):
             new_events, headers = self._query_event_page(contributor, page)
             events.extend(new_events)
-
             if not self._check_events_left(new_events, headers):
                 break
         return events
@@ -200,6 +201,9 @@ class APIManager:
         Compute the features of a contributor.
         """
         events = self.query_events(contributor)
+        if len(events) < self.min_events:
+            return None
+
         activities = self.events_to_activities(events)
         activities_df = self.activity_to_df(activities)
         features = self._extract_features(activities_df, contributor)

--- a/src/api_manager.py
+++ b/src/api_manager.py
@@ -1,0 +1,161 @@
+from abc import abstractmethod
+
+import numpy as np
+import pandas as pd
+# Have to rename to avoid the problem with double underscore.
+from important_features import __stats as stats, __convert_col_type as convert_col_type
+
+
+class APIManager:
+    """
+    Abstract class for an API manager.
+
+    Attributes:
+        api_key: The API key to use the API
+        max_queries: The maximum number of pages to query
+    """
+
+
+    def __init__(self, api_key, max_queries=3):
+        self.api_key = api_key
+        self.max_queries = max_queries
+
+    @abstractmethod
+    def _query_event_page(self, contributor, page):
+        """
+        Abstract method to query a page of events of a contributor from the API.
+
+        Parameters:
+            contributor: The username of the contributor
+            page: The page number to query
+
+        Returns:
+            A list of dictionaries corresponding to the events of a contributor
+        """
+        pass
+
+    def query_events(self, contributor):
+        """
+        Query the events of a contributor from the GitHub API.
+        A maximum of `max_queries` pages are queried where each page contains 100 events.
+        """
+        events = []
+        for page in range(1, self.max_queries + 1):
+            new_events = self._query_event_page(contributor, page)
+            events.extend(new_events)
+
+            if len(new_events) < 100:
+
+                break
+        return events
+
+    @abstractmethod
+    def events_to_activities(self, events):
+        """
+        Abstract method to convert the events to activities.
+
+        Parameters:
+            events: A list of dictionaries corresponding to the events of a contributor
+
+        Returns:
+            A list of dictionaries corresponding to the activities of a contributor
+        """
+        pass
+
+    @staticmethod
+    def activity_to_df(activities):
+        """
+        Convert the activities to a DataFrame compatible with the RABBIT feature extractor.
+
+        The returned DataFrame will have the following columns:
+        - 'date'
+        - 'activity'
+        - 'contributor'
+        - 'repository' (shape: 'owner/repo')
+
+        Parameters:
+            activities: A list of dictionaries corresponding to the activities of a contributor
+
+        Returns:
+            A DataFrame with the columns 'date', 'activity', 'contributor' and 'repository'
+        """
+        activities_df = pd.DataFrame()
+        for activity in activities:
+            new_row = pd.DataFrame([[
+                activity['start_date'],
+                activity['activity'],
+                activity['actor']['login'],
+                activity['repository']['name']
+            ]], columns=['date', 'activity', 'contributor', 'repository'])
+            activities_df = pd.concat([activities_df, new_row], ignore_index=True)
+        activities_df['date'] = (pd.to_datetime(activities_df['date'], errors='coerce', format='%Y-%m-%dT%H:%M:%SZ')
+                                 .dt.tz_localize(None))
+        return activities_df
+
+    @staticmethod
+    def _extract_features(df, contributor):
+        """
+        Extract the features from the activities of a user.
+        It uses the same features as the RABBIT feature extractor but does not remove some features
+        (NR, DCA_iqr, NAR_std, NTR_IQR, NCAR_median, NCAR_gini, DCAR_gini).
+
+        args:
+        - df: activity DataFrame with the columns 'date', 'activity', 'contributor' and 'repository (owner/repo)'
+
+        returns: A DataFrame with the features extracted from the user's activities
+
+        The features that are extracted are:
+        - NA: number of activities,
+        - NT: number of activity types,
+        - NOR: number of owners of repositories,
+        - *NR*: number of repositories,
+        - ORR: Owner repository ratio,
+        - DCA: time difference between consecutive activities (mean, median, std and gini, *IQR*),
+        - NAR: number of activities per repository (mean, median, gini and IQR, *std*),
+        - NTR: number of activity types per repository (mean, median, std and gini, *IQR),
+        - NCAR: number of continuous activities in a repo (mean, std and IQR, *median*, *gini*),
+        - DCAR: total time taken to perform consecutive activities in a repo (mean, median, std and IQR, *gini*),
+        - DAAR: time taken to switch repos (mean, median, std, gini and IQR),
+        - DCAT: time taken to switch activity type (mean, median, std, gini and IQR),
+        - NAT: number of activities per type (mean, median, std, gini and IQR).
+        """
+        features = ['NA', 'NT', 'NR','NOR','ORR',
+                    'NAR_mean', 'NAR_median', 'NAR_std', 'NAR_gini', 'NAR_IQR',
+                    'NAT_mean', 'NAT_median', 'NAT_std', 'NAT_gini', 'NAT_IQR',
+                    'NCAR_mean', 'NCAR_median', 'NCAR_std', 'NCAR_gini', 'NCAR_IQR',
+                    'NTR_mean', 'NTR_median', 'NTR_std', 'NTR_gini', 'NTR_IQR',
+                    'DCAR_mean', 'DCAR_median', 'DCAR_std', 'DCAR_gini', 'DCAR_IQR',
+                    'DAAR_mean', 'DAAR_median', 'DAAR_std', 'DAAR_gini', 'DAAR_IQR',
+                    'DCA_mean', 'DCA_median', 'DCA_std', 'DCA_gini', 'DCA_IQR',
+                    'DCAT_mean', 'DCAT_median', 'DCAT_std', 'DCAT_gini', 'DCAT_IQR',
+                    ]
+
+        df['date'] = pd.to_datetime(df.date, errors='coerce', format='%Y-%m-%dT%H:%M:%S+00:00').dt.tz_localize(None)
+        df[['owner', 'repo']] = df.repository.str.split('/', expand=True)
+
+        # Extract features using RABBIT extractor
+        df_feat = pd.json_normalize(stats(df), sep='_')
+
+        # Add column 'NR' for Number of Repositories
+        df_feat['NR'] = np.int64(df['repository'].nunique())
+
+        df_feat = (
+            convert_col_type(df_feat)
+            .rename(columns={'feat_NA':'NA', 'feat_NT':'NT', 'feat_NOR':'NOR', 'feat_ORR':'ORR'})
+            [features] # Reorder the columns
+            .sort_index()
+            .set_index([[contributor]])
+        )
+
+        return df_feat
+
+
+    def compute_features(self, contributor):
+        """
+        Compute the features of a contributor.
+        """
+        events = self.query_events(contributor)
+        activities = self.events_to_activities(events)
+        activities_df = self.activity_to_df(activities)
+        features = self._extract_features(activities_df, contributor)
+        return features

--- a/src/gh_api.py
+++ b/src/gh_api.py
@@ -1,0 +1,98 @@
+from datetime import datetime
+from importlib.resources import files
+
+import rabbit as rb
+from ghmap.mapping.action_mapper import ActionMapper
+from ghmap.mapping.activity_mapper import ActivityMapper
+from ghmap.utils import load_json_file
+
+from src.api_manager import APIManager
+import requests
+
+class GitHubManager(APIManager):
+
+    def __init__(self, api_key=None, max_queries=3):
+        super().__init__(api_key, max_queries)
+        self.query_root = 'https://api.github.com'
+
+    def _query_event_page(self, contributor, page):
+        """
+        Query a page of events of a contributor from the GitHub API.
+        """
+        query = f'{self.query_root}/users/{contributor}/events?per_page=100&page=<page>'
+        headers = {}
+        if self.api_key:
+            headers['Authorization'] = f'token {self.api_key}'
+        response = requests.get(query, headers=headers)
+
+        if response.ok:
+            # Return the events as a list of dictionaries
+            return response.json()
+        else:
+            print(f"Error while querying {contributor}: {response.status_code}")
+            return []
+
+    def query_user_type(self, contributor):
+        """
+        Query the type of contributor from the GitHub API.
+        """
+        query = f'{self.query_root}/users/{contributor}'
+        headers = {}
+        if self.api_key:
+            headers['Authorization'] = f'token {self.api_key}'
+        response = requests.get(query, headers=headers)
+
+        if response.ok:
+            # Print the remaining number of queries
+            reset_time = datetime.fromtimestamp(int(response.headers['X-RateLimit-Reset'])).strftime(
+                '%Y-%m-%d %H:%M:%S')
+            print(
+                f"Querying {contributor} : Remaining queries: {response.headers['X-RateLimit-Remaining']}. It will reset at {reset_time}")
+
+            rb.check_ratelimit(int(response.headers['X-RateLimit-Remaining']), int(response.headers['X-RateLimit-Reset']),
+                            4)
+
+            return response.json()['type']
+        else:
+            print(f"Error while querying {contributor}: {response.status_code}")
+            return 'Invalid'
+
+
+    def events_to_activities(self, events):
+        """
+        Convert the events to activities using ghmap.
+
+        Parameters:
+            events: A list of dictionaries corresponding to the events of a contributor
+
+        Returns:
+            A list of dictionaries corresponding to the activities of a contributor
+        """
+
+        # Step 1: Event to Action Mapping
+        event_to_action_mapping_file = files("src").joinpath("resources/config", "event_to_action.json")
+        action_mapping = load_json_file(event_to_action_mapping_file)
+        action_mapper = ActionMapper(action_mapping)
+
+        actions = action_mapper.map(events)
+
+        # Step 2: Actions to Activities Mapping
+        action_to_activity_mapping_file = files("src").joinpath("resources/config", "action_to_activity.json")
+        activity_mapping = load_json_file(action_to_activity_mapping_file)
+        activity_mapper = ActivityMapper(activity_mapping)
+
+        activities = activity_mapper.map(actions)
+
+        return activities
+
+if __name__ == '__main__':
+    KEY = None
+    gh_api = GitHubManager(KEY)
+
+    # Test the query_events method
+    raw_events = gh_api.query_events('MrRose765')
+    print(len(raw_events))
+    print(raw_events[0])
+
+    features = gh_api.compute_features('MrRose765')
+    print(features)

--- a/src/gh_api.py
+++ b/src/gh_api.py
@@ -37,6 +37,12 @@ class GitHubManager(APIManager):
         """
         return len(events) == 100
 
+    def _get_repo_owner(self, activity):
+        """
+        Get the owner of the repository where the activity took place.
+        """
+        return activity['repository']['name'].split('/')[0]
+
     def query_user_type(self, contributor):
         """
         Query the type of contributor from the GitHub API.
@@ -58,7 +64,6 @@ class GitHubManager(APIManager):
         else:
             print(f"Error while querying {contributor}: {response.status_code}")
             return 'Invalid'
-
 
     def events_to_activities(self, events):
         """
@@ -88,13 +93,14 @@ class GitHubManager(APIManager):
         return activities
 
 if __name__ == '__main__':
+    import model_utils as mod
+
     KEY = None
+    contributor = 'MrRose765'
     gh_api = GitHubManager(KEY)
 
-    # Test the query_events method
-    raw_events = gh_api.query_events('MrRose765')
-    print(len(raw_events))
-    print(raw_events[0])
+    features = gh_api.compute_features(contributor)
 
-    features = gh_api.compute_features('MrRose765')
-    print(features)
+    model = mod.load_model("resources/models/bimbas.joblib")
+    label, confidence = mod.predict_contributor(features, model)
+    print(f"Contributor {contributor} is a {label} with confidence {confidence}")

--- a/src/gh_api.py
+++ b/src/gh_api.py
@@ -26,10 +26,16 @@ class GitHubManager(APIManager):
         response = requests.get(query, headers=headers)
 
         if response.ok:
-            return response.json()
+            return response.json(), response.headers
         else:
             print(f"Error while querying {contributor}: {response.status_code}")
             return []
+
+    def _check_events_left(self, events, headers):
+        """
+        Check if there are events left to query from the GitHub API.
+        """
+        return len(events) == 100
 
     def query_user_type(self, contributor):
         """

--- a/src/gh_api.py
+++ b/src/gh_api.py
@@ -26,7 +26,6 @@ class GitHubManager(APIManager):
         response = requests.get(query, headers=headers)
 
         if response.ok:
-            # Return the events as a list of dictionaries
             return response.json()
         else:
             print(f"Error while querying {contributor}: {response.status_code}")
@@ -43,14 +42,11 @@ class GitHubManager(APIManager):
         response = requests.get(query, headers=headers)
 
         if response.ok:
-            # Print the remaining number of queries
-            reset_time = datetime.fromtimestamp(int(response.headers['X-RateLimit-Reset'])).strftime(
-                '%Y-%m-%d %H:%M:%S')
-            print(
-                f"Querying {contributor} : Remaining queries: {response.headers['X-RateLimit-Remaining']}. It will reset at {reset_time}")
-
-            rb.check_ratelimit(int(response.headers['X-RateLimit-Remaining']), int(response.headers['X-RateLimit-Reset']),
-                            4)
+            query_remaining = int(response.headers['X-RateLimit-Remaining'])
+            if query_remaining < self.max_queries:
+                reset_time = (datetime.fromtimestamp(int(response.headers['X-RateLimit-Reset']))
+                    .strftime('%Y-%m-%d %H:%M:%S'))
+                self.wait_reset(reset_time)
 
             return response.json()['type']
         else:

--- a/src/gl_api.py
+++ b/src/gl_api.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+
+import requests
+
+from src.api_manager import APIManager
+
+
+class GitLabManager(APIManager):
+        def __init__(self, api_key=None, max_queries=3):
+            super().__init__(api_key, max_queries)
+            self.query_root = 'https://gitlab.com/api/v4'
+
+        def _query_event_page(self, contributor, page):
+            """
+            Query a page of events of a contributor from the GitLab API.
+            """
+            query = f'{self.query_root}/users/{contributor}/events?per_page=100&page={page}'
+            headers = {}
+            if self.api_key:
+                headers['Private-Token'] = self.api_key
+            response = requests.get(query, headers=headers)
+
+            if response.ok:
+                # Return the events as a list of dictionaries
+                return response.json()
+            elif response.status_code == 429:
+                print("Rate limit exceeded", end=' ')
+                reset_time = (datetime.fromtimestamp(int(response.headers['RateLimit-Reset']))
+                              .strftime('%Y-%m-%d %H:%M:%S'))
+                self.wait_reset(reset_time)
+            else:
+                print(f"Error while querying {contributor}: {response.status_code}")
+                return []
+
+
+        def events_to_activities(self, events):
+            """
+            Convert the events to activities using glmap.
+
+            Parameters:
+                events: A list of dictionaries corresponding to the events of a contributor
+            """
+            # Error if called
+            raise NotImplementedError("Method not implemented")
+
+if __name__ == '__main__':
+    user = 'louciole'
+    gl_manager = GitLabManager()
+    events = gl_manager.query_events(user)
+    print(f"Number of events: {len(events)}")
+    print(events[0])

--- a/src/gl_api.py
+++ b/src/gl_api.py
@@ -49,7 +49,7 @@ class GitLabManager(APIManager):
                 self.wait_reset(reset_time)
             else:
                 print(f"Error while querying {contributor}: {response.status_code}")
-                return []
+                return [], response.headers
 
         def _check_events_left(self, events, headers):
             """
@@ -152,12 +152,13 @@ class GitLabManager(APIManager):
 if __name__ == '__main__':
     import model_utils as mod
 
-    user = 'imagebuilder-bot'
+    #user = 'imagebuilder-bot'
+    user = 1786152
     api_key = None
-    gl_manager = GitLabManager(api_key, before="2024-11-30", after="2024-11-28")
-    id = gl_manager.query_user_info(user)[0]['id']
+    gl_manager = GitLabManager(api_key,  before="2025-01-21", after="2024-10-21")
+    #id = gl_manager.query_user_info(user)[0]['id']
     # pretty print the response
-    print(id)
+    #print(id)
 
     # project_info = gl_manager._query_repo_info(278964)
 

--- a/src/gl_api.py
+++ b/src/gl_api.py
@@ -6,15 +6,27 @@ from src.api_manager import APIManager
 
 
 class GitLabManager(APIManager):
-        def __init__(self, api_key=None, max_queries=3):
+        def __init__(self, api_key=None, max_queries=3, before=None, after=None):
+            """
+            Initialize the GitLab API manager.
+
+            Parameters:
+                api_key: The API key to access the GitLab API
+                max_queries: The maximum number of queries to be made to the GitLab API
+                before: The date before which events are queried. (Format: YYYY-MM-DD)
+                after: The date after which events are queried. (Format: YYYY-MM-DD)
+            """
             super().__init__(api_key, max_queries)
             self.query_root = 'https://gitlab.com/api/v4'
+            # Query parameters
+            self.before = "&before=" + before if before else ""
+            self.after = "&after=" + after if after else ""
 
         def _query_event_page(self, contributor, page):
             """
             Query a page of events of a contributor from the GitLab API.
             """
-            query = f'{self.query_root}/users/{contributor}/events?per_page=100&page={page}'
+            query = f'{self.query_root}/users/{contributor}/events?per_page=100&page={page}{self.before}{self.after}'
             headers = {}
             if self.api_key:
                 headers['Private-Token'] = self.api_key
@@ -87,11 +99,13 @@ class GitLabManager(APIManager):
 
 if __name__ == '__main__':
     user = 'Louciole'
-    api_key = 'glpat-x-N-DUbxABov6fwMALBr'
-    gl_manager = GitLabManager(api_key)
+    api_key = None
+    gl_manager = GitLabManager(api_key, before="2024-11-30", after="2024-11-28")
     id = gl_manager.query_user_id(user)
     # pretty print the response
     print(id)
 
-    type_ = gl_manager.query_user_type(id)
-    print(type_)
+    events = gl_manager.query_events(user)
+    print(f"Number of events: {len(events)}")
+    for event in events:
+        print(event['created_at'])

--- a/src/model_utils.py
+++ b/src/model_utils.py
@@ -1,0 +1,36 @@
+import warnings
+
+import joblib
+import rabbit as rb
+
+
+def predict_contributor(features, model):
+    """
+    Predict if a contributor is a bot or not with a given model (BIMBAS architecture).
+
+    Parameters:
+        features: A DataFrame with the features of the contributor.
+        model: The model to use to predict the type of contributor.
+
+    Returns:
+        contributor_type (str) - type of contributor determined based on probability ('Bot' or 'Human')
+        confidence (float) - confidence score of the determined type (value between 0.0 and 1.0)
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        proba = model.predict_proba(features)
+    return rb.compute_confidence(proba[0][1])
+
+def load_model(model_path=None):
+    """
+    Load a .joblib model from a given path. If no path is provided, the default model from RABBIT is loaded.
+
+    Parameters:
+        model_path (str) - path to the model to load (default: None)
+
+    Returns:
+        model - loaded model
+    """
+    if not model_path:
+        return rb.get_model()
+    return joblib.load(model_path)

--- a/src/resources/config/action_to_activity.json
+++ b/src/resources/config/action_to_activity.json
@@ -1,4 +1,5 @@
 {
+    "tqdm_disable": true,
     "activities": [
       {
         "name": "MakeRepositoryPublic",

--- a/src/resources/config/event_to_action.json
+++ b/src/resources/config/event_to_action.json
@@ -1,625 +1,629 @@
 {
-    "metadata": {
-      "version": "1.1",
-      "description": "Mapping of GitHub event types to action types.",
-      "author": "Youness Hourri",
-      "created": "2024-10-07",
-      "license": "MIT"
+  "metadata": {
+    "version": "1.1",
+    "description": "Mapping of GitHub event types to action types.",
+    "author": "Youness Hourri",
+    "created": "2024-10-07",
+    "license": "MIT"
+  },
+  "parameters": {
+    "event_type": "type",
+    "tqdm_disable": true
+  },
+  "common_fields": {
+    "event_id": "id",
+    "date": "created_at",
+    "actor": {
+      "id": "actor.id",
+      "login": "actor.login"
     },
-    "common_fields": {
-      "event_id": "id",
-      "date": "created_at",
-      "actor": {
-        "id": "actor.id",
-        "login": "actor.login"
+    "repository": {
+      "id": "repo.id",
+      "name": "repo.name",
+      "organisation": "org.login",
+      "organisation_id": "org.id"
+    }
+  },
+  "actions": {
+    "CommentCommit": {
+      "event": {
+        "type": "CommitCommentEvent"
       },
-      "repository": {
-        "id": "repo.id",
-        "name": "repo.name",
-        "organisation": "org.login",
-        "organisation_id": "org.id"
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "commit_comment": {
+            "id": "payload.comment.id",
+            "commit": "payload.comment.commit_id",
+            "file_line": "payload.comment.line",
+            "file_path": "payload.comment.path"
+          }
+        }
       }
     },
-    "actions": {
-      "CommentCommit": {
-        "event": {
-          "type": "CommitCommentEvent"
-        },
-        "attributes": {
-          "include_common_fields": true,
-          "details": {
-            "commit_comment": {
-              "id": "payload.comment.id",
-              "commit": "payload.comment.commit_id",
-              "file_line": "payload.comment.line",
-              "file_path": "payload.comment.path"
+    "CreateBranch": {
+      "event": {
+        "type": "CreateEvent",
+        "payload": {
+          "ref_type": "branch"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "branch": {
+            "name": "payload.ref",
+            "description": "payload.description"
+          }
+        }
+      }
+    },
+    "CreateRepository": {
+      "event": {
+        "type": "CreateEvent",
+        "payload": {
+          "ref_type": "repository"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "repository": {
+            "main_branch": "payload.master_branch",
+            "description": "payload.description"
+          }
+        }
+      }
+    },
+    "CreateTag": {
+      "event": {
+        "type": "CreateEvent",
+        "payload": {
+          "ref_type": "tag"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "tag_name": "payload.ref"
+        }
+      }
+    },
+    "DeleteBranch": {
+      "event": {
+        "type": "DeleteEvent",
+        "payload": {
+          "ref_type": "branch"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "branch_name": "payload.ref"
+        }
+      }
+    },
+    "DeleteTag": {
+      "event": {
+        "type": "DeleteEvent",
+        "payload": {
+          "ref_type": "tag"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "tag_name": "payload.ref"
+        }
+      }
+    },
+    "ForkRepository": {
+      "event": {
+        "type": "ForkEvent"
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "fork": {
+            "id": "payload.forkee.id",
+            "name": "payload.forkee.full_name",
+            "description": "payload.forkee.description",
+            "main_branch": "payload.forkee.default_branch"
+          }
+        }
+      }
+    },
+    "ManageWikiPage": {
+      "event": {
+        "type": "GollumEvent"
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "pages": [
+            {
+              "name": "payload.pages.page_name",
+              "action": "payload.pages.action",
+              "commit": "payload.pages.sha"
             }
+          ]
+        }
+      }
+    },
+    "CreateIssueComment": {
+      "event": {
+        "type": "IssueCommentEvent",
+        "payload": {
+          "action": "created",
+          "issue": {
+            "html_url": "^https://github\\.com/.+/issues/\\d+$"
           }
         }
       },
-      "CreateBranch": {
-        "event": {
-          "type": "CreateEvent",
-          "payload": {
-            "ref_type": "branch"
-          }
-        },
-        "attributes": {
-          "include_common_fields": true,
-          "details": {
-            "branch": {
-              "name": "payload.ref",
-              "description": "payload.description"
-            }
-          }
-        }
-      },
-      "CreateRepository": {
-        "event": {
-          "type": "CreateEvent",
-          "payload": {
-            "ref_type": "repository"
-          }
-        },
-        "attributes": {
-          "include_common_fields": true,
-          "details": {
-            "repository": {
-              "main_branch": "payload.master_branch",
-              "description": "payload.description"
-            }
-          }
-        }
-      },
-      "CreateTag": {
-        "event": {
-          "type": "CreateEvent",
-          "payload": {
-            "ref_type": "tag"
-          }
-        },
-        "attributes": {
-          "include_common_fields": true,
-          "details": {
-            "tag_name": "payload.ref"
-          }
-        }
-      },
-      "DeleteBranch": {
-        "event": {
-          "type": "DeleteEvent",
-          "payload": {
-            "ref_type": "branch"
-          }
-        },
-        "attributes": {
-          "include_common_fields": true,
-          "details": {
-            "branch_name": "payload.ref"
-          }
-        }
-      },
-      "DeleteTag": {
-        "event": {
-          "type": "DeleteEvent",
-          "payload": {
-            "ref_type": "tag"
-          }
-        },
-        "attributes": {
-          "include_common_fields": true,
-          "details": {
-            "tag_name": "payload.ref"
-          }
-        }
-      },
-      "ForkRepository": {
-        "event": {
-          "type": "ForkEvent"
-        },
-        "attributes": {
-          "include_common_fields": true,
-          "details": {
-            "fork": {
-              "id": "payload.forkee.id",
-              "name": "payload.forkee.full_name",
-              "description": "payload.forkee.description",
-              "main_branch": "payload.forkee.default_branch"
-            }
-          }
-        }
-      },
-      "ManageWikiPage": {
-        "event": {
-          "type": "GollumEvent"
-        },
-        "attributes": {
-          "include_common_fields": true,
-          "details": {
-            "pages": [
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "issue": {
+            "id": "payload.issue.id",
+            "number": "payload.issue.number",
+            "title": "payload.issue.title",
+            "state": "payload.issue.state",
+            "author": {
+              "id": "payload.issue.user.id",
+              "login": "payload.issue.user.login"
+            },
+            "labels": [
               {
-                "name": "payload.pages.page_name",
-                "action": "payload.pages.action",
-                "commit": "payload.pages.sha"
+                "name": "payload.issue.labels.name",
+                "description": "payload.issue.labels.description"
               }
-            ]
+            ],
+            "created_date": "payload.issue.created_at",
+            "updated_date": "payload.issue.updated_at",
+            "closed_date": "payload.issue.closed_at"
+          },
+          "comment": {
+            "id": "payload.comment.id",
+            "position": "payload.issue.comments"
+          }
+        }
+      }
+    },
+    "CreatePullRequestComment": {
+      "event": {
+        "type": "IssueCommentEvent",
+        "payload": {
+          "action": "created",
+          "issue": {
+            "html_url": "^https://github\\.com/.+/pull/\\d+$"
           }
         }
       },
-      "CreateIssueComment": {
-        "event": {
-          "type": "IssueCommentEvent",
-          "payload": {
-            "action": "created",
-            "issue": {
-              "html_url": "^https://github\\.com/.+/issues/\\d+$"
-            }
-          }
-        },
-        "attributes": {
-          "include_common_fields": true,
-          "details": {
-            "issue": {
-              "id": "payload.issue.id",
-              "number": "payload.issue.number",
-              "title": "payload.issue.title",
-              "state": "payload.issue.state",
-              "author": {
-                "id": "payload.issue.user.id",
-                "login": "payload.issue.user.login"
-              },
-              "labels": [
-                {
-                  "name": "payload.issue.labels.name",
-                  "description": "payload.issue.labels.description"
-                }
-              ],
-              "created_date": "payload.issue.created_at",
-              "updated_date": "payload.issue.updated_at",
-              "closed_date": "payload.issue.closed_at"
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "pull_request": {
+            "id": "payload.issue.id",
+            "number": "payload.issue.number",
+            "title": "payload.issue.title",
+            "state": "payload.issue.state",
+            "author": {
+              "id": "payload.issue.user.id",
+              "login": "payload.issue.user.login"
             },
-            "comment": {
-              "id": "payload.comment.id",
-              "position": "payload.issue.comments"
-            }
+            "labels": [
+              {
+                "name": "payload.issue.labels.name",
+                "description": "payload.issue.labels.description"
+              }
+            ],
+            "created_date": "payload.issue.created_at",
+            "updated_date": "payload.issue.updated_at",
+            "closed_date": "payload.issue.closed_at",
+            "merged_date": "payload.issue.pull_request.merged_at"
+          },
+          "comment": {
+            "id": "payload.comment.id",
+            "position": "payload.issue.comments"
           }
         }
+      }
+    },
+    "CloseIssue": {
+      "event": {
+        "type": "IssuesEvent",
+        "payload": {
+          "action": "closed"
+        }
       },
-      "CreatePullRequestComment": {
-        "event": {
-          "type": "IssueCommentEvent",
-          "payload": {
-            "action": "created",
-            "issue": {
-              "html_url": "^https://github\\.com/.+/pull/\\d+$"
-            }
-          }
-        },
-        "attributes": {
-          "include_common_fields": true,
-          "details": {
-            "pull_request": {
-              "id": "payload.issue.id",
-              "number": "payload.issue.number",
-              "title": "payload.issue.title",
-              "state": "payload.issue.state",
-              "author": {
-                "id": "payload.issue.user.id",
-                "login": "payload.issue.user.login"
-              },
-              "labels": [
-                {
-                  "name": "payload.issue.labels.name",
-                  "description": "payload.issue.labels.description"
-                }
-              ],
-              "created_date": "payload.issue.created_at",
-              "updated_date": "payload.issue.updated_at",
-              "closed_date": "payload.issue.closed_at",
-              "merged_date": "payload.issue.pull_request.merged_at"
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "issue": {
+            "id": "payload.issue.id",
+            "number": "payload.issue.number",
+            "title": "payload.issue.title",
+            "state": "payload.issue.state",
+            "author": {
+              "id": "payload.issue.user.id",
+              "login": "payload.issue.user.login"
             },
-            "comment": {
-              "id": "payload.comment.id",
-              "position": "payload.issue.comments"
-            }
+            "labels": [
+              {
+                "name": "payload.issue.labels.name",
+                "description": "payload.issue.labels.description"
+              }
+            ],
+            "created_date": "payload.issue.created_at",
+            "updated_date": "payload.issue.updated_at",
+            "closed_date": "payload.issue.closed_at"
           }
         }
-      },
-      "CloseIssue": {
-        "event": {
-          "type": "IssuesEvent",
-          "payload": {
-            "action": "closed"
-          }
-        },
-        "attributes": {
-          "include_common_fields": true,
-          "details": {
-            "issue": {
-              "id": "payload.issue.id",
-              "number": "payload.issue.number",
-              "title": "payload.issue.title",
-              "state": "payload.issue.state",
-              "author": {
-                "id": "payload.issue.user.id",
-                "login": "payload.issue.user.login"
-              },
-              "labels": [
-                {
-                  "name": "payload.issue.labels.name",
-                  "description": "payload.issue.labels.description"
-                }
-              ],
-              "created_date": "payload.issue.created_at",
-              "updated_date": "payload.issue.updated_at",
-              "closed_date": "payload.issue.closed_at"
-            }
-          }
+      }
+    },
+    "OpenIssue": {
+      "event": {
+        "type": "IssuesEvent",
+        "payload": {
+          "action": "opened"
         }
       },
-      "OpenIssue": {
-        "event": {
-          "type": "IssuesEvent",
-          "payload": {
-            "action": "opened"
-          }
-        },
-        "attributes": {
-          "include_common_fields": true,
-          "details": {
-            "issue": {
-              "id": "payload.issue.id",
-              "number": "payload.issue.number",
-              "title": "payload.issue.title",
-              "state": "payload.issue.state",
-              "author": {
-                "id": "payload.issue.user.id",
-                "login": "payload.issue.user.login"
-              },
-              "labels": [
-                {
-                  "name": "payload.issue.labels.name",
-                  "description": "payload.issue.labels.description"
-                }
-              ],
-              "created_date": "payload.issue.created_at",
-              "updated_date": "payload.issue.updated_at",
-              "closed_date": "payload.issue.closed_at"
-            }
-          }
-        }
-      },
-      "ReopenIssue": {
-        "event": {
-          "type": "IssuesEvent",
-          "payload": {
-            "action": "reopened"
-          }
-        },
-        "attributes": {
-          "include_common_fields": true,
-          "details": {
-            "issue": {
-              "id": "payload.issue.id",
-              "number": "payload.issue.number",
-              "title": "payload.issue.title",
-              "state": "payload.issue.state",
-              "author": {
-                "id": "payload.issue.user.id",
-                "login": "payload.issue.user.login"
-              },
-              "labels": [
-                {
-                  "name": "payload.issue.labels.name",
-                  "description": "payload.issue.labels.description"
-                }
-              ],
-              "created_date": "payload.issue.created_at",
-              "updated_date": "payload.issue.updated_at",
-              "closed_date": "payload.issue.closed_at"
-            }
-          }
-        }
-      },
-      "AddMember": {
-        "event": {
-          "type": "MemberEvent",
-          "payload": {
-            "action": "added"
-          }
-        },
-        "attributes": {
-          "include_common_fields": true,
-          "details": {
-            "member": {
-              "id": "payload.member.id",
-              "login": "payload.member.login"
-            }
-          }
-        }
-      },
-      "MakeRepositoryPublic": {
-        "event": {
-          "type": "PublicEvent"
-        },
-        "attributes": {
-          "include_common_fields": true
-        }
-      },
-      "MergePullRequest": {
-        "event": {
-          "type": "PullRequestEvent",
-          "payload": {
-            "action": "closed",
-            "pull_request": {
-              "merged": true
-            }
-          }
-        },
-        "attributes": {
-          "include_common_fields": true,
-          "details": {
-            "pull_request": {
-              "id": "payload.pull_request.id",
-              "number": "payload.pull_request.number",
-              "title": "payload.pull_request.title",
-              "state": "payload.pull_request.state",
-              "author": {
-                "id": "payload.pull_request.user.id",
-                "login": "payload.pull_request.user.login"
-              },
-              "labels": [
-                {
-                  "name": "payload.pull_request.labels.name",
-                  "description": "payload.pull_request.labels.description"
-                }
-              ],
-              "created_date": "payload.pull_request.created_at",
-              "updated_date": "payload.pull_request.updated_at",
-              "closed_date": "payload.pull_request.closed_at",
-              "merged": "payload.pull_request.merged"
-            }
-          }
-        }
-      },
-      "ClosePullRequest": {
-        "event": {
-          "type": "PullRequestEvent",
-          "payload": {
-            "action": "closed",
-            "pull_request": {
-              "merged": false
-            }
-          }
-        },
-        "attributes": {
-          "include_common_fields": true,
-          "details": {
-            "pull_request": {
-              "id": "payload.pull_request.id",
-              "number": "payload.pull_request.number",
-              "title": "payload.pull_request.title",
-              "state": "payload.pull_request.state",
-              "author": {
-                "id": "payload.pull_request.user.id",
-                "login": "payload.pull_request.user.login"
-              },
-              "labels": [
-                {
-                  "name": "payload.pull_request.labels.name",
-                  "description": "payload.pull_request.labels.description"
-                }
-              ],
-              "created_date": "payload.pull_request.created_at",
-              "updated_date": "payload.pull_request.updated_at",
-              "closed_date": "payload.pull_request.closed_at",
-              "merged": "payload.pull_request.merged"
-            }
-          }
-        }
-      },
-      "OpenPullRequest": {
-        "event": {
-          "type": "PullRequestEvent",
-          "payload": {
-            "action": "opened"
-          }
-        },
-        "attributes": {
-          "include_common_fields": true,
-          "details": {
-            "pull_request": {
-              "id": "payload.pull_request.id",
-              "number": "payload.pull_request.number",
-              "title": "payload.pull_request.title",
-              "state": "payload.pull_request.state",
-              "author": {
-                "id": "payload.pull_request.user.id",
-                "login": "payload.pull_request.user.login"
-              },
-              "labels": [
-                {
-                  "name": "payload.pull_request.labels.name",
-                  "description": "payload.pull_request.labels.description"
-                }
-              ],
-              "created_date": "payload.pull_request.created_at",
-              "updated_date": "payload.pull_request.updated_at",
-              "closed_date": "payload.pull_request.closed_at",
-              "merged": "payload.pull_request.merged"
-            }
-          }
-        }
-      },
-      "ReopenPullRequest": {
-        "event": {
-          "type": "PullRequestEvent",
-          "payload": {
-            "action": "reopened"
-          }
-        },
-        "attributes": {
-          "include_common_fields": true,
-          "details": {
-            "pull_request": {
-              "id": "payload.pull_request.id",
-              "number": "payload.pull_request.number",
-              "title": "payload.pull_request.title",
-              "state": "payload.pull_request.state",
-              "author": {
-                "id": "payload.pull_request.user.id",
-                "login": "payload.pull_request.user.login"
-              },
-              "labels": [
-                {
-                  "name": "payload.pull_request.labels.name",
-                  "description": "payload.pull_request.labels.description"
-                }
-              ],
-              "created_date": "payload.pull_request.created_at",
-              "updated_date": "payload.pull_request.updated_at",
-              "closed_date": "payload.pull_request.closed_at",
-              "merged": "payload.pull_request.merged"
-            }
-          }
-        }
-      },
-      "CreatePullRequestReviewComment": {
-        "event": {
-          "type": "PullRequestReviewCommentEvent",
-          "payload": {
-            "action": "created"
-          }
-        },
-        "attributes": {
-          "include_common_fields": true,
-          "details": {
-            "pull_request": {
-              "id": "payload.pull_request.id",
-              "number": "payload.pull_request.number",
-              "title": "payload.pull_request.title",
-              "state": "payload.pull_request.state",
-              "author": {
-                "id": "payload.pull_request.user.id",
-                "login": "payload.pull_request.user.login"
-              },
-              "labels": [
-                {
-                  "name": "payload.pull_request.labels.name",
-                  "description": "payload.pull_request.labels.description"
-                }
-              ],
-              "created_date": "payload.pull_request.created_at",
-              "updated_date": "payload.pull_request.updated_at",
-              "closed_date": "payload.pull_request.closed_at",
-              "merged_date": "payload.pull_request.pull_request.merged_at"
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "issue": {
+            "id": "payload.issue.id",
+            "number": "payload.issue.number",
+            "title": "payload.issue.title",
+            "state": "payload.issue.state",
+            "author": {
+              "id": "payload.issue.user.id",
+              "login": "payload.issue.user.login"
             },
-            "review": {
-              "id": "payload.comment.pull_request_review_id",
-              "updated_date": "payload.comment.updated_at"
+            "labels": [
+              {
+                "name": "payload.issue.labels.name",
+                "description": "payload.issue.labels.description"
+              }
+            ],
+            "created_date": "payload.issue.created_at",
+            "updated_date": "payload.issue.updated_at",
+            "closed_date": "payload.issue.closed_at"
+          }
+        }
+      }
+    },
+    "ReopenIssue": {
+      "event": {
+        "type": "IssuesEvent",
+        "payload": {
+          "action": "reopened"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "issue": {
+            "id": "payload.issue.id",
+            "number": "payload.issue.number",
+            "title": "payload.issue.title",
+            "state": "payload.issue.state",
+            "author": {
+              "id": "payload.issue.user.id",
+              "login": "payload.issue.user.login"
             },
-            "comment": {
-              "id": "payload.comment.id",
-              "parent_comment_id": "payload.comment.in_reply_to_id"
-            }
+            "labels": [
+              {
+                "name": "payload.issue.labels.name",
+                "description": "payload.issue.labels.description"
+              }
+            ],
+            "created_date": "payload.issue.created_at",
+            "updated_date": "payload.issue.updated_at",
+            "closed_date": "payload.issue.closed_at"
+          }
+        }
+      }
+    },
+    "AddMember": {
+      "event": {
+        "type": "MemberEvent",
+        "payload": {
+          "action": "added"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "member": {
+            "id": "payload.member.id",
+            "login": "payload.member.login"
+          }
+        }
+      }
+    },
+    "MakeRepositoryPublic": {
+      "event": {
+        "type": "PublicEvent"
+      },
+      "attributes": {
+        "include_common_fields": true
+      }
+    },
+    "MergePullRequest": {
+      "event": {
+        "type": "PullRequestEvent",
+        "payload": {
+          "action": "closed",
+          "pull_request": {
+            "merged": true
           }
         }
       },
-      "CreatePullRequestReview": {
-        "event": {
-          "type": "PullRequestReviewEvent",
-          "payload": {
-            "action": "created"
-          }
-        },
-        "attributes": {
-          "include_common_fields": true,
-          "details": {
-            "pull_request": {
-              "id": "payload.pull_request.id",
-              "number": "payload.pull_request.number",
-              "title": "payload.pull_request.title",
-              "state": "payload.pull_request.state",
-              "author": {
-                "id": "payload.pull_request.user.id",
-                "login": "payload.pull_request.user.login"
-              },
-              "labels": [
-                {
-                  "name": "payload.pull_request.labels.name",
-                  "description": "payload.pull_request.labels.description"
-                }
-              ],
-              "created_date": "payload.pull_request.created_at",
-              "updated_date": "payload.pull_request.updated_at",
-              "closed_date": "payload.pull_request.closed_at",
-              "merged_date": "payload.pull_request.pull_request.merged_at"
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "pull_request": {
+            "id": "payload.pull_request.id",
+            "number": "payload.pull_request.number",
+            "title": "payload.pull_request.title",
+            "state": "payload.pull_request.state",
+            "author": {
+              "id": "payload.pull_request.user.id",
+              "login": "payload.pull_request.user.login"
             },
-            "review": {
-              "id": "payload.review.id",
-              "submitted_date": "payload.review.submitted_at"
-            }
+            "labels": [
+              {
+                "name": "payload.pull_request.labels.name",
+                "description": "payload.pull_request.labels.description"
+              }
+            ],
+            "created_date": "payload.pull_request.created_at",
+            "updated_date": "payload.pull_request.updated_at",
+            "closed_date": "payload.pull_request.closed_at",
+            "merged": "payload.pull_request.merged"
+          }
+        }
+      }
+    },
+    "ClosePullRequest": {
+      "event": {
+        "type": "PullRequestEvent",
+        "payload": {
+          "action": "closed",
+          "pull_request": {
+            "merged": false
           }
         }
       },
-      "PushCommits": {
-        "event": {
-          "type": "PushEvent"
-        },
-        "attributes": {
-          "include_common_fields": true,
-          "details": {
-            "push": {
-              "id": "payload.push_id",
-              "ref": "payload.ref",
-              "commits": "payload.size"
-            }
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "pull_request": {
+            "id": "payload.pull_request.id",
+            "number": "payload.pull_request.number",
+            "title": "payload.pull_request.title",
+            "state": "payload.pull_request.state",
+            "author": {
+              "id": "payload.pull_request.user.id",
+              "login": "payload.pull_request.user.login"
+            },
+            "labels": [
+              {
+                "name": "payload.pull_request.labels.name",
+                "description": "payload.pull_request.labels.description"
+              }
+            ],
+            "created_date": "payload.pull_request.created_at",
+            "updated_date": "payload.pull_request.updated_at",
+            "closed_date": "payload.pull_request.closed_at",
+            "merged": "payload.pull_request.merged"
           }
+        }
+      }
+    },
+    "OpenPullRequest": {
+      "event": {
+        "type": "PullRequestEvent",
+        "payload": {
+          "action": "opened"
         }
       },
-      "PublishRelease": {
-        "event": {
-          "type": "ReleaseEvent",
-          "payload": {
-            "action": "published"
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "pull_request": {
+            "id": "payload.pull_request.id",
+            "number": "payload.pull_request.number",
+            "title": "payload.pull_request.title",
+            "state": "payload.pull_request.state",
+            "author": {
+              "id": "payload.pull_request.user.id",
+              "login": "payload.pull_request.user.login"
+            },
+            "labels": [
+              {
+                "name": "payload.pull_request.labels.name",
+                "description": "payload.pull_request.labels.description"
+              }
+            ],
+            "created_date": "payload.pull_request.created_at",
+            "updated_date": "payload.pull_request.updated_at",
+            "closed_date": "payload.pull_request.closed_at",
+            "merged": "payload.pull_request.merged"
           }
-        },
-        "attributes": {
-          "include_common_fields": true,
-          "details": {
-            "release": {
-              "id": "payload.release.id",
-              "name": "payload.release.name",
-              "tag": "payload.release.tag_name",
-              "author": {
-                "id": "payload.release.author.id",
-                "login": "payload.release.author.login"
-              },
-              "draft": "payload.release.draft",
-              "prerelease": "payload.release.prerelease",
-              "created_date": "payload.release.created_at"
-            }
-          }
+        }
+      }
+    },
+    "ReopenPullRequest": {
+      "event": {
+        "type": "PullRequestEvent",
+        "payload": {
+          "action": "reopened"
         }
       },
-      "StarRepository": {
-        "event": {
-          "type": "WatchEvent",
-          "payload": {
-            "action": "started"
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "pull_request": {
+            "id": "payload.pull_request.id",
+            "number": "payload.pull_request.number",
+            "title": "payload.pull_request.title",
+            "state": "payload.pull_request.state",
+            "author": {
+              "id": "payload.pull_request.user.id",
+              "login": "payload.pull_request.user.login"
+            },
+            "labels": [
+              {
+                "name": "payload.pull_request.labels.name",
+                "description": "payload.pull_request.labels.description"
+              }
+            ],
+            "created_date": "payload.pull_request.created_at",
+            "updated_date": "payload.pull_request.updated_at",
+            "closed_date": "payload.pull_request.closed_at",
+            "merged": "payload.pull_request.merged"
           }
-        },
-        "attributes": {
-          "include_common_fields": true
+        }
+      }
+    },
+    "CreatePullRequestReviewComment": {
+      "event": {
+        "type": "PullRequestReviewCommentEvent",
+        "payload": {
+          "action": "created"
         }
       },
-      "UnknownAction": {
-        "event": {
-          "type": "*"
-        },
-        "attributes": {
-          "include_common_fields": true
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "pull_request": {
+            "id": "payload.pull_request.id",
+            "number": "payload.pull_request.number",
+            "title": "payload.pull_request.title",
+            "state": "payload.pull_request.state",
+            "author": {
+              "id": "payload.pull_request.user.id",
+              "login": "payload.pull_request.user.login"
+            },
+            "labels": [
+              {
+                "name": "payload.pull_request.labels.name",
+                "description": "payload.pull_request.labels.description"
+              }
+            ],
+            "created_date": "payload.pull_request.created_at",
+            "updated_date": "payload.pull_request.updated_at",
+            "closed_date": "payload.pull_request.closed_at",
+            "merged_date": "payload.pull_request.pull_request.merged_at"
+          },
+          "review": {
+            "id": "payload.comment.pull_request_review_id",
+            "updated_date": "payload.comment.updated_at"
+          },
+          "comment": {
+            "id": "payload.comment.id",
+            "parent_comment_id": "payload.comment.in_reply_to_id"
+          }
         }
+      }
+    },
+    "CreatePullRequestReview": {
+      "event": {
+        "type": "PullRequestReviewEvent",
+        "payload": {
+          "action": "created"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "pull_request": {
+            "id": "payload.pull_request.id",
+            "number": "payload.pull_request.number",
+            "title": "payload.pull_request.title",
+            "state": "payload.pull_request.state",
+            "author": {
+              "id": "payload.pull_request.user.id",
+              "login": "payload.pull_request.user.login"
+            },
+            "labels": [
+              {
+                "name": "payload.pull_request.labels.name",
+                "description": "payload.pull_request.labels.description"
+              }
+            ],
+            "created_date": "payload.pull_request.created_at",
+            "updated_date": "payload.pull_request.updated_at",
+            "closed_date": "payload.pull_request.closed_at",
+            "merged_date": "payload.pull_request.pull_request.merged_at"
+          },
+          "review": {
+            "id": "payload.review.id",
+            "submitted_date": "payload.review.submitted_at"
+          }
+        }
+      }
+    },
+    "PushCommits": {
+      "event": {
+        "type": "PushEvent"
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "push": {
+            "id": "payload.push_id",
+            "ref": "payload.ref",
+            "commits": "payload.size"
+          }
+        }
+      }
+    },
+    "PublishRelease": {
+      "event": {
+        "type": "ReleaseEvent",
+        "payload": {
+          "action": "published"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "release": {
+            "id": "payload.release.id",
+            "name": "payload.release.name",
+            "tag": "payload.release.tag_name",
+            "author": {
+              "id": "payload.release.author.id",
+              "login": "payload.release.author.login"
+            },
+            "draft": "payload.release.draft",
+            "prerelease": "payload.release.prerelease",
+            "created_date": "payload.release.created_at"
+          }
+        }
+      }
+    },
+    "StarRepository": {
+      "event": {
+        "type": "WatchEvent",
+        "payload": {
+          "action": "started"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true
+      }
+    },
+    "UnknownAction": {
+      "event": {
+        "type": "*"
+      },
+      "attributes": {
+        "include_common_fields": true
       }
     }
   }
+}

--- a/src/resources/config/gl_action_to_activity.json
+++ b/src/resources/config/gl_action_to_activity.json
@@ -23,6 +23,17 @@
       ]
     },
     {
+      "name": "CommentWikiPages",
+      "time_window": "3600s",
+      "actions": [
+        {
+          "action": "CreateWikiPageComment",
+          "optional": false,
+          "repeat": true
+        }
+      ]
+    },
+    {
       "name": "AcceptMergeRequest",
       "time_window": "4s",
       "actions": [
@@ -109,17 +120,54 @@
           "action": "CreateCommitCommentWithThread",
           "optional": true,
           "repeat": true
+        },
+        {
+          "action": "CreateCommitReviewComment",
+          "optional": true,
+          "repeat": true
         }
       ]
     },
     {
       "name": "CreateIssue",
-      "time_window": "0s",
+      "time_window": "3s",
       "actions": [
         {
           "action": "CreateIssue",
           "optional": false,
           "repeat": false
+        },
+        {
+          "action": "CreateIssueComment",
+          "optional": true,
+          "repeat": false,
+          "validate_with": [
+            {
+              "target_action": "CreateIssue",
+              "fields": [
+                {
+                  "field": "issue.id",
+                  "target_field": "issue.id"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "action": "CreateIssueCommentWithThread",
+          "optional": true,
+          "repeat": false,
+          "validate_with": [
+            {
+              "target_action": "CreateIssue",
+              "fields": [
+                {
+                  "field": "issue.id",
+                  "target_field": "issue.id"
+                }
+              ]
+            }
+          ]
         }
       ]
     },
@@ -174,6 +222,38 @@
           "action": "CreateMergeRequest",
           "optional": false,
           "repeat": false
+        },
+        {
+          "action": "CreateMergeRequestComment",
+          "optional": true,
+          "repeat": false,
+          "validate_with": [
+            {
+              "target_action": "CreateMergeRequest",
+              "fields": [
+                {
+                  "field": "merge_request.id",
+                  "target_field": "merge_request.id"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "action": "CreateMergeRequestCommentWithThread",
+          "optional": true,
+          "repeat": false,
+          "validate_with": [
+            {
+              "target_action": "CreateMergeRequest",
+              "fields": [
+                {
+                  "field": "merge_request.id",
+                  "target_field": "merge_request.id"
+                }
+              ]
+            }
+          ]
         }
       ]
     },
@@ -199,15 +279,6 @@
                   "target_field": "merge_request.id"
                 }
               ]
-            },
-            {
-              "target_action": "CreateMergeRequestCommentWithThread",
-              "fields": [
-                {
-                  "field": "merge_request.id",
-                  "target_field": "merge_request.id"
-                }
-              ]
             }
           ]
         },
@@ -218,15 +289,6 @@
           "validate_with": [
             {
               "target_action": "CloseMergeRequest",
-              "fields": [
-                {
-                  "field": "merge_request.id",
-                  "target_field": "merge_request.id"
-                }
-              ]
-            },
-            {
-              "target_action": "CreateMergeRequestComment",
               "fields": [
                 {
                   "field": "merge_request.id",
@@ -352,18 +414,18 @@
     },
     {
       "name": "PushCommits",
-      "time_window": "2s",
+      "time_window": "0s",
       "actions": [
         {
           "action": "PushCommits",
           "optional": false,
-          "repeat": true
+          "repeat": false
         }
       ]
     },
     {
       "name": "ReviewMergeRequest",
-      "time_window": "300s",
+      "time_window": "5s",
       "actions": [
         {
           "action": "ApproveMergeRequest",
@@ -380,7 +442,7 @@
               ]
             },
             {
-              "target_action": "ApproveMergeRequest",
+              "target_action": "CreateMergeRequestCommentWithThread",
               "fields": [
                 {
                   "field": "merge_request.id",
@@ -412,6 +474,49 @@
                   "target_field": "merge_request.id"
                 }
               ]
+            },
+            {
+              "target_action": "CreateMergeRequestCommentWithThread",
+              "fields": [
+                {
+                  "field": "merge_request.id",
+                  "target_field": "merge_request.id"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "action": "CreateMergeRequestCommentWithThread",
+          "optional": true,
+          "repeat": true,
+          "validate_with": [
+            {
+              "target_action": "CreateMergeRequestReviewComment",
+              "fields": [
+                {
+                  "field": "merge_request.id",
+                  "target_field": "merge_request.id"
+                }
+              ]
+            },
+            {
+              "target_action": "ApproveMergeRequest",
+              "fields": [
+                {
+                  "field": "merge_request.id",
+                  "target_field": "merge_request.id"
+                }
+              ]
+            },
+            {
+              "target_action": "CreateMergeRequestCommentWithThread",
+              "fields": [
+                {
+                  "field": "merge_request.id",
+                  "target_field": "merge_request.id"
+                }
+              ]
             }
           ]
         }
@@ -435,6 +540,17 @@
           "action": "ExpireProjectMembership",
           "optional": true,
           "repeat": false
+        }
+      ]
+    },
+    {
+      "name": "ImportProjects",
+      "time_window": "3600s",
+      "actions": [
+        {
+          "action": "ImportProject",
+          "optional": false,
+          "repeat": true
         }
       ]
     },
@@ -571,18 +687,34 @@
       ]
     },
     {
-      "name": "CreateWorkItems",
-      "time_window": "300s",
+      "name": "CreateWorkItem",
+      "time_window": "3s",
       "actions": [
         {
           "action": "CreateWorkItem",
           "optional": false,
           "repeat": true
+        },
+        {
+          "action": "CreateIssueComment",
+          "optional": true,
+          "repeat": false,
+          "validate_with": [
+            {
+              "target_action": "CreateWorkItem",
+              "fields": [
+                {
+                  "field": "issue.id",
+                  "target_field": "work_item.id"
+                }
+              ]
+            }
+          ]
         }
       ]
     },
     {
-      "name": "CloseWorkItems",
+      "name": "CloseWorkItem",
       "time_window": "3s",
       "actions": [
         {

--- a/src/resources/config/gl_action_to_activity.json
+++ b/src/resources/config/gl_action_to_activity.json
@@ -414,12 +414,12 @@
     },
     {
       "name": "PushCommits",
-      "time_window": "0s",
+      "time_window": "2s",
       "actions": [
         {
           "action": "PushCommits",
           "optional": false,
-          "repeat": false
+          "repeat": true
         }
       ]
     },

--- a/src/resources/config/gl_action_to_activity.json
+++ b/src/resources/config/gl_action_to_activity.json
@@ -416,6 +416,197 @@
           ]
         }
       ]
+    },
+    {
+      "name": "UpdateProjectMembership",
+      "time_window": "0s",
+      "actions": [
+        {
+          "action": "JoinProject",
+          "optional": true,
+          "repeat": false
+        },
+        {
+          "action": "LeftProject",
+          "optional": true,
+          "repeat": false
+        },
+        {
+          "action": "ExpireProjectMembership",
+          "optional": true,
+          "repeat": false
+        }
+      ]
+    },
+    {
+      "name": "ManageDesigns",
+      "time_window": "3s",
+      "actions": [
+        {
+          "action": "AddDesign",
+          "optional": true,
+          "repeat": true
+        },
+        {
+          "action": "UpdateDesign",
+          "optional": true,
+          "repeat": true
+        },
+        {
+          "action": "RemoveDesign",
+          "optional": true,
+          "repeat": true
+        }
+      ]
+    },
+    {
+      "name": "CommentDesign",
+      "time_window": "300s",
+      "actions": [
+        {
+          "action": "CreateDesignComment",
+          "optional": false,
+          "repeat": true,
+          "validate_with": [
+            {
+              "target_action": "CreateDesignComment",
+              "fields": [
+                {
+                  "field": "design.id",
+                  "target_field": "design.id"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "CreateMilestone",
+      "time_window": "0s",
+      "actions": [
+        {
+          "action": "CreateMilestone",
+          "optional": false,
+          "repeat": false
+        }
+      ]
+    },
+    {
+      "name": "CloseMilestone",
+      "time_window": "0s",
+      "actions": [
+        {
+          "action": "CloseMilestone",
+          "optional": false,
+          "repeat": false
+        }
+      ]
+    },
+    {
+      "name": "DestroyMilestone",
+      "time_window": "0s",
+      "actions": [
+        {
+          "action": "DestroyMilestone",
+          "optional": false,
+          "repeat": false
+        }
+      ]
+    },
+    {
+      "name": "CommentSnippet",
+      "time_window": "300s",
+      "actions": [
+        {
+          "action": "CreateSnippetComment",
+          "optional": true,
+          "repeat": true,
+          "validate_with": [
+            {
+              "target_action": "CreateSnippetComment",
+              "fields": [
+                {
+                  "field": "snippet.id",
+                  "target_field": "snippet.id"
+                }
+              ]
+            },
+            {
+              "target_action": "CreateSnippetCommentWithThread",
+              "fields": [
+                {
+                  "field": "snippet.id",
+                  "target_field": "snippet.id"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "action": "CreateSnippetCommentWithThread",
+          "optional": true,
+          "repeat": true,
+          "validate_with": [
+            {
+              "target_action": "CreateSnippetComment",
+              "fields": [
+                {
+                  "field": "snippet.id",
+                  "target_field": "snippet.id"
+                }
+              ]
+            },
+            {
+              "target_action": "CreateSnippetCommentWithThread",
+              "fields": [
+                {
+                  "field": "snippet.id",
+                  "target_field": "snippet.id"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "CreateWorkItems",
+      "time_window": "300s",
+      "actions": [
+        {
+          "action": "CreateWorkItem",
+          "optional": false,
+          "repeat": true
+        }
+      ]
+    },
+    {
+      "name": "CloseWorkItems",
+      "time_window": "3s",
+      "actions": [
+        {
+          "action": "CloseWorkItem",
+          "optional": false,
+          "repeat": true
+        },
+        {
+          "action": "CreateIssueComment",
+          "optional": true,
+          "repeat": false,
+          "validate_with": [
+            {
+              "target_action": "CloseWorkItem",
+              "fields": [
+                {
+                  "field": "issue.id",
+                  "target_field": "work_item.id"
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/resources/config/gl_action_to_activity.json
+++ b/src/resources/config/gl_action_to_activity.json
@@ -45,7 +45,7 @@
         {
           "action": "PushCommits",
           "optional": true,
-          "repeat": true
+          "repeat": false
         },
         {
           "action": "DeleteBranch",
@@ -598,37 +598,25 @@
       ]
     },
     {
-      "name": "CreateMilestone",
-      "time_window": "0s",
-      "actions": [
-        {
-          "action": "CreateMilestone",
-          "optional": false,
-          "repeat": false
-        }
-      ]
-    },
-    {
-      "name": "CloseMilestone",
-      "time_window": "0s",
-      "actions": [
-        {
-          "action": "CloseMilestone",
-          "optional": false,
-          "repeat": false
-        }
-      ]
-    },
-    {
-      "name": "DestroyMilestone",
-      "time_window": "0s",
-      "actions": [
-        {
-          "action": "DestroyMilestone",
-          "optional": false,
-          "repeat": false
-        }
-      ]
+      "name": "ManageMilestones",
+        "time_window": "3s",
+        "actions": [
+          {
+            "action": "CreateMilestone",
+            "optional": true,
+            "repeat": true
+          },
+          {
+            "action": "CloseMilestone",
+            "optional": true,
+            "repeat": true
+          },
+          {
+            "action": "DestroyMilestone",
+            "optional": true,
+            "repeat": true
+          }
+        ]
     },
     {
       "name": "CommentSnippet",
@@ -693,7 +681,7 @@
         {
           "action": "CreateWorkItem",
           "optional": false,
-          "repeat": true
+          "repeat": false
         },
         {
           "action": "CreateIssueComment",
@@ -720,7 +708,7 @@
         {
           "action": "CloseWorkItem",
           "optional": false,
-          "repeat": true
+          "repeat": false
         },
         {
           "action": "CreateIssueComment",

--- a/src/resources/config/gl_action_to_activity.json
+++ b/src/resources/config/gl_action_to_activity.json
@@ -216,7 +216,7 @@
     },
     {
       "name": "CreateMergeRequest",
-      "time_window": "0s",
+      "time_window": "3s",
       "actions": [
         {
           "action": "CreateMergeRequest",

--- a/src/resources/config/gl_action_to_activity.json
+++ b/src/resources/config/gl_action_to_activity.json
@@ -1,0 +1,421 @@
+{
+  "tqdm_disable": true,
+  "activities": [
+    {
+      "name": "ManageWikiPages",
+      "time_window": "3600s",
+      "actions": [
+        {
+          "action": "CreateWikiPage",
+          "optional": true,
+          "repeat": true
+        },
+        {
+          "action": "DestroyWikiPage",
+          "optional": true,
+          "repeat": true
+        },
+        {
+          "action": "UpdateWikiPage",
+          "optional": true,
+          "repeat": true
+        }
+      ]
+    },
+    {
+      "name": "AcceptMergeRequest",
+      "time_window": "4s",
+      "actions": [
+        {
+          "action": "AcceptMergeRequest",
+          "optional": false,
+          "repeat": false
+        },
+        {
+          "action": "PushCommits",
+          "optional": true,
+          "repeat": true
+        },
+        {
+          "action": "DeleteBranch",
+          "optional": true,
+          "repeat": false
+        },
+        {
+          "action": "CloseIssue",
+          "optional": true,
+          "repeat": true
+        }
+      ]
+    },
+    {
+      "name": "CreateProject",
+      "time_window": "3s",
+      "actions": [
+        {
+          "action": "CreateProject",
+          "optional": false,
+          "repeat": false
+        },
+        {
+          "action": "CreateBranch",
+          "optional": true,
+          "repeat": false
+        }
+      ]
+    },
+    {
+      "name": "ManageBranches",
+      "time_window": "3s",
+      "actions": [
+        {
+          "action": "CreateBranch",
+          "optional": true,
+          "repeat": true
+        },
+        {
+          "action": "DeleteBranch",
+          "optional": true,
+          "repeat": true
+        }
+      ]
+    },
+    {
+      "name": "ManageTags",
+      "time_window": "3s",
+      "actions": [
+        {
+          "action": "CreateTag",
+          "optional": "true",
+          "repeat": "true"
+        },
+        {
+          "action": "DeleteTag",
+          "optional": "true",
+          "repeat": "true"
+        }
+      ]
+    },
+    {
+      "name": "CommentCommits",
+      "time_window": "300s",
+      "actions": [
+        {
+          "action": "CreateCommitComment",
+          "optional": true,
+          "repeat": true
+        },
+        {
+          "action": "CreateCommitCommentWithThread",
+          "optional": true,
+          "repeat": true
+        }
+      ]
+    },
+    {
+      "name": "CreateIssue",
+      "time_window": "0s",
+      "actions": [
+        {
+          "action": "CreateIssue",
+          "optional": false,
+          "repeat": false
+        }
+      ]
+    },
+    {
+      "name": "CloseIssue",
+      "time_window": "3s",
+      "actions": [
+        {
+          "action": "CloseIssue",
+          "optional": false,
+          "repeat": false
+        },
+        {
+          "action": "CreateIssueComment",
+          "optional": true,
+          "repeat": false,
+          "validate_with": [
+            {
+              "target_action": "CloseIssue",
+              "fields": [
+                {
+                  "field": "issue.id",
+                  "target_field": "issue.id"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "action": "CreateIssueCommentWithThread",
+          "optional": true,
+          "repeat": false,
+          "validate_with": [
+            {
+              "target_action": "CloseIssue",
+              "fields": [
+                {
+                  "field": "issue.id",
+                  "target_field": "issue.id"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "CreateMergeRequest",
+      "time_window": "0s",
+      "actions": [
+        {
+          "action": "CreateMergeRequest",
+          "optional": false,
+          "repeat": false
+        }
+      ]
+    },
+    {
+      "name": "CloseMergeRequest",
+      "time_window": "3s",
+      "actions": [
+        {
+          "action": "CloseMergeRequest",
+          "optional": false,
+          "repeat": false
+        },
+        {
+          "action": "CreateMergeRequestComment",
+          "optional": true,
+          "repeat": false,
+          "validate_with": [
+            {
+              "target_action": "CloseMergeRequest",
+              "fields": [
+                {
+                  "field": "merge_request.id",
+                  "target_field": "merge_request.id"
+                }
+              ]
+            },
+            {
+              "target_action": "CreateMergeRequestCommentWithThread",
+              "fields": [
+                {
+                  "field": "merge_request.id",
+                  "target_field": "merge_request.id"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "action": "CreateMergeRequestCommentWithThread",
+          "optional": true,
+          "repeat": false,
+          "validate_with": [
+            {
+              "target_action": "CloseMergeRequest",
+              "fields": [
+                {
+                  "field": "merge_request.id",
+                  "target_field": "merge_request.id"
+                }
+              ]
+            },
+            {
+              "target_action": "CreateMergeRequestComment",
+              "fields": [
+                {
+                  "field": "merge_request.id",
+                  "target_field": "merge_request.id"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "CommentIssue",
+      "time_window": "300s",
+      "actions": [
+        {
+          "action": "CreateIssueComment",
+          "optional": true,
+          "repeat": true,
+          "validate_with": [
+            {
+              "target_action": "CreateIssueComment",
+              "fields": [
+                {
+                  "field": "issue.id",
+                  "target_field": "issue.id"
+                }
+              ]
+            },
+            {
+              "target_action": "CreateIssueCommentWithThread",
+              "fields": [
+                {
+                  "field": "issue.id",
+                  "target_field": "issue.id"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "action": "CreateIssueCommentWithThread",
+          "optional": true,
+          "repeat": true,
+          "validate_with": [
+            {
+              "target_action": "CreateIssueComment",
+              "fields": [
+                {
+                  "field": "issue.id",
+                  "target_field": "issue.id"
+                }
+              ]
+            },
+            {
+              "target_action": "CreateIssueCommentWithThread",
+              "fields": [
+                {
+                  "field": "issue.id",
+                  "target_field": "issue.id"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "CommentMergeRequest",
+      "time_window": "300s",
+      "actions": [
+        {
+          "action": "CreateMergeRequestComment",
+          "optional": true,
+          "repeat": true,
+          "validate_with": [
+            {
+              "target_action": "CreateMergeRequestComment",
+              "fields": [
+                {
+                  "field": "merge_request.id",
+                  "target_field": "merge_request.id"
+                }
+              ]
+            },
+            {
+              "target_action": "CreateMergeRequestCommentWithThread",
+              "fields": [
+                {
+                  "field": "merge_request.id",
+                  "target_field": "merge_request.id"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "action": "CreateMergeRequestCommentWithThread",
+          "optional": true,
+          "repeat": true,
+          "validate_with": [
+            {
+              "target_action": "CreateMergeRequestComment",
+              "fields": [
+                {
+                  "field": "merge_request.id",
+                  "target_field": "merge_request.id"
+                }
+              ]
+            },
+            {
+              "target_action": "CreateMergeRequestCommentWithThread",
+              "fields": [
+                {
+                  "field": "merge_request.id",
+                  "target_field": "merge_request.id"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PushCommits",
+      "time_window": "2s",
+      "actions": [
+        {
+          "action": "PushCommits",
+          "optional": false,
+          "repeat": true
+        }
+      ]
+    },
+    {
+      "name": "ReviewMergeRequest",
+      "time_window": "300s",
+      "actions": [
+        {
+          "action": "ApproveMergeRequest",
+          "optional": true,
+          "repeat": false,
+          "validate_with": [
+            {
+              "target_action": "CreateMergeRequestReviewComment",
+              "fields": [
+                {
+                  "field": "merge_request.id",
+                  "target_field": "merge_request.id"
+                }
+              ]
+            },
+            {
+              "target_action": "ApproveMergeRequest",
+              "fields": [
+                {
+                  "field": "merge_request.id",
+                  "target_field": "merge_request.id"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "action": "CreateMergeRequestReviewComment",
+          "optional": true,
+          "repeat": true,
+          "validate_with": [
+            {
+              "target_action": "CreateMergeRequestReviewComment",
+              "fields": [
+                {
+                  "field": "merge_request.id",
+                  "target_field": "merge_request.id"
+                }
+              ]
+            },
+            {
+              "target_action": "ApproveMergeRequest",
+              "fields": [
+                {
+                  "field": "merge_request.id",
+                  "target_field": "merge_request.id"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/resources/config/gl_action_to_activity.json
+++ b/src/resources/config/gl_action_to_activity.json
@@ -34,11 +34,11 @@
       ]
     },
     {
-      "name": "AcceptMergeRequest",
+      "name": "MergePullRequest",
       "time_window": "4s",
       "actions": [
         {
-          "action": "AcceptMergeRequest",
+          "action": "MergePullRequest",
           "optional": false,
           "repeat": false
         },
@@ -60,11 +60,11 @@
       ]
     },
     {
-      "name": "CreateProject",
+      "name": "CreateRepository",
       "time_window": "3s",
       "actions": [
         {
-          "action": "CreateProject",
+          "action": "CreateRepository",
           "optional": false,
           "repeat": false
         },
@@ -215,41 +215,41 @@
       ]
     },
     {
-      "name": "CreateMergeRequest",
+      "name": "CreatePullRequest",
       "time_window": "3s",
       "actions": [
         {
-          "action": "CreateMergeRequest",
+          "action": "CreatePullRequest",
           "optional": false,
           "repeat": false
         },
         {
-          "action": "CreateMergeRequestComment",
+          "action": "CreatePullRequestComment",
           "optional": true,
           "repeat": false,
           "validate_with": [
             {
-              "target_action": "CreateMergeRequest",
+              "target_action": "CreatePullRequest",
               "fields": [
                 {
-                  "field": "merge_request.id",
-                  "target_field": "merge_request.id"
+                  "field": "pull_request.id",
+                  "target_field": "pull_request.id"
                 }
               ]
             }
           ]
         },
         {
-          "action": "CreateMergeRequestCommentWithThread",
+          "action": "CreatePullRequestCommentWithThread",
           "optional": true,
           "repeat": false,
           "validate_with": [
             {
-              "target_action": "CreateMergeRequest",
+              "target_action": "CreatePullRequest",
               "fields": [
                 {
-                  "field": "merge_request.id",
-                  "target_field": "merge_request.id"
+                  "field": "pull_request.id",
+                  "target_field": "pull_request.id"
                 }
               ]
             }
@@ -258,41 +258,41 @@
       ]
     },
     {
-      "name": "CloseMergeRequest",
+      "name": "ClosePullRequest",
       "time_window": "3s",
       "actions": [
         {
-          "action": "CloseMergeRequest",
+          "action": "ClosePullRequest",
           "optional": false,
           "repeat": false
         },
         {
-          "action": "CreateMergeRequestComment",
+          "action": "CreatePullRequestComment",
           "optional": true,
           "repeat": false,
           "validate_with": [
             {
-              "target_action": "CloseMergeRequest",
+              "target_action": "ClosePullRequest",
               "fields": [
                 {
-                  "field": "merge_request.id",
-                  "target_field": "merge_request.id"
+                  "field": "pull_request.id",
+                  "target_field": "pull_request.id"
                 }
               ]
             }
           ]
         },
         {
-          "action": "CreateMergeRequestCommentWithThread",
+          "action": "CreatePullRequestCommentWithThread",
           "optional": true,
           "repeat": false,
           "validate_with": [
             {
-              "target_action": "CloseMergeRequest",
+              "target_action": "ClosePullRequest",
               "fields": [
                 {
-                  "field": "merge_request.id",
-                  "target_field": "merge_request.id"
+                  "field": "pull_request.id",
+                  "target_field": "pull_request.id"
                 }
               ]
             }
@@ -357,54 +357,54 @@
       ]
     },
     {
-      "name": "CommentMergeRequest",
+      "name": "CommentPullRequest",
       "time_window": "300s",
       "actions": [
         {
-          "action": "CreateMergeRequestComment",
+          "action": "CreatePullRequestComment",
           "optional": true,
           "repeat": true,
           "validate_with": [
             {
-              "target_action": "CreateMergeRequestComment",
+              "target_action": "CreatePullRequestComment",
               "fields": [
                 {
-                  "field": "merge_request.id",
-                  "target_field": "merge_request.id"
+                  "field": "pull_request.id",
+                  "target_field": "pull_request.id"
                 }
               ]
             },
             {
-              "target_action": "CreateMergeRequestCommentWithThread",
+              "target_action": "CreatePullRequestCommentWithThread",
               "fields": [
                 {
-                  "field": "merge_request.id",
-                  "target_field": "merge_request.id"
+                  "field": "pull_request.id",
+                  "target_field": "pull_request.id"
                 }
               ]
             }
           ]
         },
         {
-          "action": "CreateMergeRequestCommentWithThread",
+          "action": "CreatePullRequestCommentWithThread",
           "optional": true,
           "repeat": true,
           "validate_with": [
             {
-              "target_action": "CreateMergeRequestComment",
+              "target_action": "CreatePullRequestComment",
               "fields": [
                 {
-                  "field": "merge_request.id",
-                  "target_field": "merge_request.id"
+                  "field": "pull_request.id",
+                  "target_field": "pull_request.id"
                 }
               ]
             },
             {
-              "target_action": "CreateMergeRequestCommentWithThread",
+              "target_action": "CreatePullRequestCommentWithThread",
               "fields": [
                 {
-                  "field": "merge_request.id",
-                  "target_field": "merge_request.id"
+                  "field": "pull_request.id",
+                  "target_field": "pull_request.id"
                 }
               ]
             }
@@ -424,97 +424,97 @@
       ]
     },
     {
-      "name": "ReviewMergeRequest",
+      "name": "ReviewPullRequest",
       "time_window": "5s",
       "actions": [
         {
-          "action": "ApproveMergeRequest",
+          "action": "ApprovePullRequest",
           "optional": true,
           "repeat": false,
           "validate_with": [
             {
-              "target_action": "CreateMergeRequestReviewComment",
+              "target_action": "CreatePullRequestReviewComment",
               "fields": [
                 {
-                  "field": "merge_request.id",
-                  "target_field": "merge_request.id"
+                  "field": "pull_request.id",
+                  "target_field": "pull_request.id"
                 }
               ]
             },
             {
-              "target_action": "CreateMergeRequestCommentWithThread",
+              "target_action": "CreatePullRequestCommentWithThread",
               "fields": [
                 {
-                  "field": "merge_request.id",
-                  "target_field": "merge_request.id"
+                  "field": "pull_request.id",
+                  "target_field": "pull_request.id"
                 }
               ]
             }
           ]
         },
         {
-          "action": "CreateMergeRequestReviewComment",
+          "action": "CreatePullRequestReviewComment",
           "optional": true,
           "repeat": true,
           "validate_with": [
             {
-              "target_action": "CreateMergeRequestReviewComment",
+              "target_action": "CreatePullRequestReviewComment",
               "fields": [
                 {
-                  "field": "merge_request.id",
-                  "target_field": "merge_request.id"
+                  "field": "pull_request.id",
+                  "target_field": "pull_request.id"
                 }
               ]
             },
             {
-              "target_action": "ApproveMergeRequest",
+              "target_action": "ApprovePullRequest",
               "fields": [
                 {
-                  "field": "merge_request.id",
-                  "target_field": "merge_request.id"
+                  "field": "pull_request.id",
+                  "target_field": "pull_request.id"
                 }
               ]
             },
             {
-              "target_action": "CreateMergeRequestCommentWithThread",
+              "target_action": "CreatePullRequestCommentWithThread",
               "fields": [
                 {
-                  "field": "merge_request.id",
-                  "target_field": "merge_request.id"
+                  "field": "pull_request.id",
+                  "target_field": "pull_request.id"
                 }
               ]
             }
           ]
         },
         {
-          "action": "CreateMergeRequestCommentWithThread",
+          "action": "CreatePullRequestCommentWithThread",
           "optional": true,
           "repeat": true,
           "validate_with": [
             {
-              "target_action": "CreateMergeRequestReviewComment",
+              "target_action": "CreatePullRequestReviewComment",
               "fields": [
                 {
-                  "field": "merge_request.id",
-                  "target_field": "merge_request.id"
+                  "field": "pull_request.id",
+                  "target_field": "pull_request.id"
                 }
               ]
             },
             {
-              "target_action": "ApproveMergeRequest",
+              "target_action": "ApprovePullRequest",
               "fields": [
                 {
-                  "field": "merge_request.id",
-                  "target_field": "merge_request.id"
+                  "field": "pull_request.id",
+                  "target_field": "pull_request.id"
                 }
               ]
             },
             {
-              "target_action": "CreateMergeRequestCommentWithThread",
+              "target_action": "CreatePullRequestCommentWithThread",
               "fields": [
                 {
-                  "field": "merge_request.id",
-                  "target_field": "merge_request.id"
+                  "field": "pull_request.id",
+                  "target_field": "pull_request.id"
                 }
               ]
             }
@@ -523,32 +523,32 @@
       ]
     },
     {
-      "name": "UpdateProjectMembership",
+      "name": "UpdateRepositoryMembership",
       "time_window": "0s",
       "actions": [
         {
-          "action": "JoinProject",
+          "action": "JoinRepository",
           "optional": true,
           "repeat": false
         },
         {
-          "action": "LeftProject",
+          "action": "LeftRepository",
           "optional": true,
           "repeat": false
         },
         {
-          "action": "ExpireProjectMembership",
+          "action": "ExpireRepositoryMembership",
           "optional": true,
           "repeat": false
         }
       ]
     },
     {
-      "name": "ImportProjects",
+      "name": "ImportRepositories",
       "time_window": "3600s",
       "actions": [
         {
-          "action": "ImportProject",
+          "action": "ImportRepository",
           "optional": false,
           "repeat": true
         }

--- a/src/resources/config/gl_event_to_action.json
+++ b/src/resources/config/gl_event_to_action.json
@@ -446,7 +446,7 @@
         "include_common_fields": true,
         "details": {
           "commit": {
-            "name": "target_title"
+            "title": "target_title"
           },
           "commit_comment": {
             "id": "note.id",
@@ -467,7 +467,7 @@
         "include_common_fields": true,
         "details": {
           "commit": {
-            "name": "target_title"
+            "title": "target_title"
           },
           "commit_comment": {
             "id": "note.id",
@@ -488,7 +488,7 @@
         "include_common_fields": true,
         "details": {
           "commit": {
-            "name": "target_title"
+            "title": "target_title"
           },
           "review": {
             "file": "note.position.new_path",

--- a/src/resources/config/gl_event_to_action.json
+++ b/src/resources/config/gl_event_to_action.json
@@ -93,7 +93,7 @@
         }
       }
     },
-    "AcceptMergeRequest": {
+    "MergePullRequest": {
       "event": {
         "type": "MergeRequest",
         "action_name": "accepted"
@@ -101,7 +101,7 @@
       "attributes": {
         "include_common_fields": true,
         "details": {
-          "merge_request": {
+          "pull_request": {
             "id": "target_id",
             "iid": "target_iid",
             "title": "target_title"
@@ -109,7 +109,7 @@
         }
       }
     },
-    "ApproveMergeRequest": {
+    "ApprovePullRequest": {
       "event": {
         "type": "MergeRequest",
         "action_name": "approved"
@@ -117,7 +117,7 @@
       "attributes": {
         "include_common_fields": true,
         "details": {
-          "merge_request": {
+          "pull_request": {
             "id": "target_id",
             "iid": "target_iid",
             "title": "target_title"
@@ -125,7 +125,7 @@
         }
       }
     },
-    "CreateMergeRequest": {
+    "CreatePullRequest": {
       "event": {
         "type": "MergeRequest",
         "action_name": "opened"
@@ -133,7 +133,7 @@
       "attributes": {
         "include_common_fields": true,
         "details": {
-          "merge_request": {
+          "pull_request": {
             "id": "target_id",
             "iid": "target_iid",
             "title": "target_title"
@@ -141,7 +141,7 @@
         }
       }
     },
-    "CloseMergeRequest": {
+    "ClosePullRequest": {
       "event": {
         "type": "MergeRequest",
         "action_name": "closed"
@@ -149,7 +149,7 @@
       "attributes": {
         "include_common_fields": true,
         "details": {
-          "merge_request": {
+          "pull_request": {
             "id": "target_id",
             "iid": "target_iid",
             "title": "target_title"
@@ -157,7 +157,7 @@
         }
       }
     },
-    "CreateMergeRequestComment": {
+    "CreatePullRequestComment": {
       "event": {
         "type": "Note",
         "action_name": "commented on",
@@ -168,7 +168,7 @@
       "attributes": {
         "include_common_fields": true,
         "details": {
-          "merge_request": {
+          "pull_request": {
             "id": "note.noteable_id",
             "iid": "note.noteable_iid",
             "title": "target_title"
@@ -180,7 +180,7 @@
         }
       }
     },
-    "CreateMergeRequestCommentWithThread": {
+    "CreatePullRequestCommentWithThread": {
       "event": {
         "type": "DiscussionNote",
         "action_name": "commented on",
@@ -191,7 +191,7 @@
       "attributes": {
         "include_common_fields": true,
         "details": {
-          "merge_request": {
+          "pull_request": {
             "id": "note.noteable_id",
             "iid": "note.noteable_iid",
             "title": "target_title"
@@ -203,7 +203,7 @@
         }
       }
     },
-    "CreateMergeRequestReviewComment": {
+    "CreatePullRequestReviewComment": {
       "event": {
         "type": "DiffNote",
         "action_name": "commented on",
@@ -214,7 +214,7 @@
       "attributes": {
         "include_common_fields": true,
         "details": {
-          "merge_request": {
+          "pull_request": {
             "id": "note.noteable_id",
             "iid": "note.noteable_iid",
             "title": "target_title"
@@ -230,7 +230,7 @@
         }
       }
     },
-    "JoinProject": {
+    "JoinRepository": {
       "event": {
         "action_name": "joined"
       },
@@ -238,7 +238,7 @@
         "include_common_fields": true
       }
     },
-    "ExpireProjectMembership": {
+    "ExpireRepositoryMembership": {
       "event": {
         "action_name": "removed due to membership expiration from"
       },
@@ -246,7 +246,7 @@
         "include_common_fields": true
       }
     },
-    "LeftProject": {
+    "LeftRepository": {
       "event": {
         "action_name": "left"
       },
@@ -696,7 +696,7 @@
         }
       }
     },
-    "CreateProject": {
+    "CreateRepository": {
       "event": {
         "action_name": "created"
       },
@@ -704,7 +704,7 @@
         "include_common_fields": true
       }
     },
-    "ImportProject": {
+    "ImportRepository": {
       "event": {
         "action_name": "imported"
       },

--- a/src/resources/config/gl_event_to_action.json
+++ b/src/resources/config/gl_event_to_action.json
@@ -388,6 +388,31 @@
         }
       }
     },
+    "CreateWikiPageComment": {
+      "event": {
+        "type": "Note",
+        "action_name": "commented on",
+        "note": {
+          "noteable_type": "WikiPage::Meta"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "wiki_page": {
+            "title": "target_title",
+            "slug": "wiki_page.slug",
+            "format": "wiki_page.format",
+            "id": "target_id",
+            "iid": "target_iid"
+          },
+          "comment": {
+            "id": "note.id",
+            "body": "note.body"
+          }
+        }
+      }
+    },
     "PushCommits": {
       "event": {
         "action_name": "pushed to",
@@ -460,7 +485,20 @@
         }
       },
       "attributes": {
-        "include_common_fields": true
+        "include_common_fields": true,
+        "details": {
+          "commit": {
+            "name": "target_title"
+          },
+          "review": {
+            "file": "note.position.new_path",
+            "line": "note.position.new_line"
+          },
+          "commit_review_comment": {
+            "id": "note.id",
+            "body": "note.body"
+          }
+        }
       }
     },
     "AddDesign": {
@@ -661,6 +699,14 @@
     "CreateProject": {
       "event": {
         "action_name": "created"
+      },
+      "attributes": {
+        "include_common_fields": true
+      }
+    },
+    "ImportProject": {
+      "event": {
+        "action_name": "imported"
       },
       "attributes": {
         "include_common_fields": true

--- a/src/resources/config/gl_event_to_action.json
+++ b/src/resources/config/gl_event_to_action.json
@@ -469,7 +469,14 @@
         "action_name": "added"
       },
       "attributes": {
-        "include_common_fields": true
+        "include_common_fields": true,
+        "details": {
+          "design": {
+            "id": "target_id",
+            "iid": "target_iid",
+            "filename": "target_title"
+          }
+        }
       }
     },
     "RemoveDesign": {
@@ -478,7 +485,14 @@
         "action_name": "removed"
       },
       "attributes": {
-        "include_common_fields": true
+        "include_common_fields": true,
+        "details": {
+          "design": {
+            "id": "target_id",
+            "iid": "target_iid",
+            "filename": "target_title"
+          }
+        }
       }
     },
     "CreateDesignComment": {
@@ -490,7 +504,18 @@
         }
       },
       "attributes": {
-        "include_common_fields": true
+        "include_common_fields": true,
+        "details": {
+          "design": {
+            "id": "note.noteable_id",
+            "iid": "note.noteable_iid",
+            "filename": "target_title"
+          },
+          "comment": {
+            "id": "note.id",
+            "body": "note.body"
+          }
+        }
       }
     },
     "UpdateDesign": {
@@ -499,7 +524,14 @@
         "action_name": "updated"
       },
       "attributes": {
-        "include_common_fields": true
+        "include_common_fields": true,
+        "details": {
+          "design": {
+            "id": "target_id",
+            "iid": "target_iid",
+            "filename": "target_title"
+          }
+        }
       }
     },
     "CreateMilestone": {
@@ -508,7 +540,14 @@
         "action_name": "opened"
       },
       "attributes": {
-        "include_common_fields": true
+        "include_common_fields": true,
+        "details": {
+          "milestone": {
+            "id": "target_id",
+            "iid": "target_iid",
+            "title": "target_title"
+          }
+        }
       }
     },
     "CloseMilestone": {
@@ -517,7 +556,14 @@
         "action_name": "closed"
       },
       "attributes": {
-        "include_common_fields": true
+        "include_common_fields": true,
+        "details": {
+          "milestone": {
+            "id": "target_id",
+            "iid": "target_iid",
+            "title": "target_title"
+          }
+        }
       }
     },
     "DestroyMilestone": {
@@ -526,7 +572,14 @@
         "action_name": "destroyed"
       },
       "attributes": {
-        "include_common_fields": true
+        "include_common_fields": true,
+        "details": {
+          "milestone": {
+            "id": "target_id",
+            "iid": "target_iid",
+            "title": "target_title"
+          }
+        }
       }
     },
     "CreateSnippetComment": {
@@ -538,7 +591,17 @@
         }
       },
       "attributes": {
-        "include_common_fields": true
+        "include_common_fields": true,
+        "details": {
+          "snippet": {
+            "id": "note.noteable_id",
+            "title": "target_title"
+          },
+          "comment": {
+            "id": "target_id",
+            "body": "note.body"
+          }
+        }
       }
     },
     "CreateSnippetCommentWithThread": {
@@ -550,7 +613,17 @@
         }
       },
       "attributes": {
-        "include_common_fields": true
+        "include_common_fields": true,
+        "details": {
+          "snippet": {
+            "id": "note.noteable_id",
+            "title": "target_title"
+          },
+          "comment": {
+            "id": "target_id",
+            "body": "note.body"
+          }
+        }
       }
     },
     "CreateWorkItem": {
@@ -559,7 +632,14 @@
         "action_name": "opened"
       },
       "attributes": {
-        "include_common_fields": true
+        "include_common_fields": true,
+        "details": {
+          "work_item": {
+            "id": "target_id",
+            "iid": "target_iid",
+            "title": "target_title"
+          }
+        }
       }
     },
     "CloseWorkItem": {
@@ -568,7 +648,14 @@
         "action_name": "closed"
       },
       "attributes": {
-        "include_common_fields": true
+        "include_common_fields": true,
+        "details": {
+          "work_item": {
+            "id": "target_id",
+            "iid": "target_iid",
+            "title": "target_title"
+          }
+        }
       }
     },
     "CreateProject": {

--- a/src/resources/config/gl_event_to_action.json
+++ b/src/resources/config/gl_event_to_action.json
@@ -1,0 +1,591 @@
+{
+  "parameters": {
+    "event_type": "target_type",
+    "tqdm_disable": true
+  },
+  "common_fields": {
+    "event_id": "id",
+    "date": "created_at",
+    "actor": {
+      "id": "author.id",
+      "login": "author.username"
+    },
+    "repository": {
+      "id": "project_id"
+    }
+  },
+  "actions": {
+    "CreateIssue": {
+      "event": {
+        "type": "Issue",
+        "action_name": "opened"
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "issue": {
+            "id": "target_id",
+            "iid": "target_iid",
+            "title": "target_title"
+          }
+        }
+      }
+    },
+    "CloseIssue": {
+      "event": {
+        "type": "Issue",
+        "action_name": "closed"
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "issue": {
+            "id": "target_id",
+            "iid": "target_iid",
+            "title": "target_title"
+          }
+        }
+      }
+    },
+    "CreateIssueComment": {
+      "event": {
+        "type": "Note",
+        "action_name": "commented on",
+        "note": {
+          "noteable_type": "Issue"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "issue": {
+            "id": "note.noteable_id",
+            "iid": "note.noteable_iid",
+            "title": "target_title"
+          },
+          "comment": {
+            "id": "target_id",
+            "body": "note.body"
+          }
+        }
+      }
+    },
+    "CreateIssueCommentWithThread": {
+      "event": {
+        "type": "DiscussionNote",
+        "action_name": "commented on",
+        "note": {
+          "noteable_type": "Issue"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "issue": {
+            "id": "note.noteable_id",
+            "iid": "note.noteable_iid",
+            "title": "target_title"
+          },
+          "comment": {
+            "id": "target_id",
+            "body": "note.body"
+          }
+        }
+      }
+    },
+    "AcceptMergeRequest": {
+      "event": {
+        "type": "MergeRequest",
+        "action_name": "accepted"
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "merge_request": {
+            "id": "target_id",
+            "iid": "target_iid",
+            "title": "target_title"
+          }
+        }
+      }
+    },
+    "ApproveMergeRequest": {
+      "event": {
+        "type": "MergeRequest",
+        "action_name": "approved"
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "merge_request": {
+            "id": "target_id",
+            "iid": "target_iid",
+            "title": "target_title"
+          }
+        }
+      }
+    },
+    "CreateMergeRequest": {
+      "event": {
+        "type": "MergeRequest",
+        "action_name": "opened"
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "merge_request": {
+            "id": "target_id",
+            "iid": "target_iid",
+            "title": "target_title"
+          }
+        }
+      }
+    },
+    "CloseMergeRequest": {
+      "event": {
+        "type": "MergeRequest",
+        "action_name": "closed"
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "merge_request": {
+            "id": "target_id",
+            "iid": "target_iid",
+            "title": "target_title"
+          }
+        }
+      }
+    },
+    "CreateMergeRequestComment": {
+      "event": {
+        "type": "Note",
+        "action_name": "commented on",
+        "note": {
+          "noteable_type": "MergeRequest"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "merge_request": {
+            "id": "note.noteable_id",
+            "iid": "note.noteable_iid",
+            "title": "target_title"
+          },
+          "comment": {
+            "id": "note.id",
+            "body": "note.body"
+          }
+        }
+      }
+    },
+    "CreateMergeRequestCommentWithThread": {
+      "event": {
+        "type": "DiscussionNote",
+        "action_name": "commented on",
+        "note": {
+          "noteable_type": "MergeRequest"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "merge_request": {
+            "id": "note.noteable_id",
+            "iid": "note.noteable_iid",
+            "title": "target_title"
+          },
+          "comment": {
+            "id": "note.id",
+            "body": "note.body"
+          }
+        }
+      }
+    },
+    "CreateMergeRequestReviewComment": {
+      "event": {
+        "type": "DiffNote",
+        "action_name": "commented on",
+        "note": {
+          "noteable_type": "MergeRequest"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "merge_request": {
+            "id": "note.noteable_id",
+            "iid": "note.noteable_iid",
+            "title": "target_title"
+          },
+          "review": {
+            "file": "note.position.new_path",
+            "line_range": "note.position.line_range"
+          },
+          "comment": {
+            "id": "note.id",
+            "body": "note.body"
+          }
+        }
+      }
+    },
+    "JoinProject": {
+      "event": {
+        "action_name": "joined"
+      },
+      "attributes": {
+        "include_common_fields": true
+      }
+    },
+    "ExpireProjectMembership": {
+      "event": {
+        "action_name": "removed due to membership expiration from"
+      },
+      "attributes": {
+        "include_common_fields": true
+      }
+    },
+    "LeftProject": {
+      "event": {
+        "action_name": "left"
+      },
+      "attributes": {
+        "include_common_fields": true
+      }
+    },
+    "CreateTag": {
+      "event": {
+        "action_name": "pushed new",
+        "push_data": {
+          "action": "created",
+          "ref_type": "tag"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "tag": {
+            "name": "push_data.ref",
+            "count": "push_data.ref_count"
+          }
+        }
+      }
+    },
+    "DeleteTag": {
+      "event": {
+        "action_name": "deleted",
+        "push_data": {
+          "ref_type": "tag"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "tag": {
+            "name": "push_data.ref",
+            "count": "push_data.ref_count"
+          }
+        }
+      }
+    },
+    "CreateBranch": {
+      "event": {
+        "action_name": "pushed new",
+        "push_data": {
+          "ref_type": "branch",
+          "action": "created"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "branch": {
+            "name": "push_data.ref",
+            "count": "push_data.ref_count"
+          },
+          "commit": {
+            "id": "push_data.commit_to",
+            "title": "push_data.commit_title",
+            "count": "push_data.commit_count"
+          }
+        }
+      }
+    },
+    "DeleteBranch": {
+      "event": {
+        "action_name": "deleted",
+        "push_data": {
+          "ref_type": "branch"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "branch": {
+            "name": "push_data.ref",
+            "count": "push_data.ref_count"
+          },
+          "commit": {
+            "id": "push_data.commit_to",
+            "title": "push_data.commit_title",
+            "count": "push_data.commit_count"
+          }
+        }
+      }
+    },
+    "CreateWikiPage": {
+      "event": {
+        "type": "WikiPage::Meta",
+        "action_name": "created"
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "wiki_page": {
+            "title": "target_title",
+            "slug": "wiki_page.slug",
+            "format": "wiki_page.format",
+            "id": "target_id",
+            "iid": "target_iid"
+          }
+        }
+      }
+    },
+    "DestroyWikiPage": {
+      "event": {
+        "type": "WikiPage::Meta",
+        "action_name": "destroyed"
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "wiki_page": {
+            "title": "target_title",
+            "slug": "wiki_page.slug",
+            "format": "wiki_page.format",
+            "id": "target_id",
+            "iid": "target_iid"
+          }
+        }
+      }
+    },
+    "UpdateWikiPage": {
+      "event": {
+        "type": "WikiPage::Meta",
+        "action_name": "updated"
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "wiki_page": {
+            "title": "target_title",
+            "slug": "wiki_page.slug",
+            "format": "wiki_page.format",
+            "id": "target_id",
+            "iid": "target_iid"
+          }
+        }
+      }
+    },
+    "PushCommits": {
+      "event": {
+        "action_name": "pushed to",
+        "push_data": {
+          "action": "pushed"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "commit": {
+            "id": "push_data.commit_to",
+            "title": "push_data.commit_title",
+            "count": "push_data.commit_count"
+          },
+          "branch": {
+            "name": "push_data.ref"
+          }
+        }
+      }
+    },
+    "CreateCommitComment": {
+      "event": {
+        "type": "Note",
+        "action_name": "commented on",
+        "note": {
+          "noteable_type": "Commit"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "commit": {
+            "name": "target_title"
+          },
+          "commit_comment": {
+            "id": "note.id",
+            "body": "note.body"
+          }
+        }
+      }
+    },
+    "CreateCommitCommentWithThread": {
+      "event": {
+        "type": "DiscussionNote",
+        "action_name": "commented on",
+        "note": {
+          "noteable_type": "Commit"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true,
+        "details": {
+          "commit": {
+            "name": "target_title"
+          },
+          "commit_comment": {
+            "id": "note.id",
+            "body": "note.body"
+          }
+        }
+      }
+    },
+    "CreateCommitReviewComment": {
+      "event": {
+        "type": "DiffNote",
+        "action_name": "commented on",
+        "note": {
+          "noteable_type": "Commit"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true
+      }
+    },
+    "AddDesign": {
+      "event": {
+        "type": "DesignManagement::Design",
+        "action_name": "added"
+      },
+      "attributes": {
+        "include_common_fields": true
+      }
+    },
+    "RemoveDesign": {
+      "event": {
+        "type": "DesignManagement::Design",
+        "action_name": "removed"
+      },
+      "attributes": {
+        "include_common_fields": true
+      }
+    },
+    "CreateDesignComment": {
+      "event": {
+        "type": "DiffNote",
+        "action_name": "commented on",
+        "note": {
+          "noteable_type": "DesignManagement::Design"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true
+      }
+    },
+    "UpdateDesign": {
+      "event": {
+        "type": "DesignManagement::Design",
+        "action_name": "updated"
+      },
+      "attributes": {
+        "include_common_fields": true
+      }
+    },
+    "CreateMilestone": {
+      "event": {
+        "type": "Milestone",
+        "action_name": "opened"
+      },
+      "attributes": {
+        "include_common_fields": true
+      }
+    },
+    "CloseMilestone": {
+      "event": {
+        "type": "Milestone",
+        "action_name": "closed"
+      },
+      "attributes": {
+        "include_common_fields": true
+      }
+    },
+    "DestroyMilestone": {
+      "event": {
+        "type": "Milestone",
+        "action_name": "destroyed"
+      },
+      "attributes": {
+        "include_common_fields": true
+      }
+    },
+    "CreateSnippetComment": {
+      "event": {
+        "type": "Note",
+        "action_name": "commented on",
+        "note": {
+          "noteable_type": "Snippet"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true
+      }
+    },
+    "CreateSnippetCommentWithThread": {
+      "event": {
+        "type": "DiscussionNote",
+        "action_name": "commented on",
+        "note": {
+          "noteable_type": "Snippet"
+        }
+      },
+      "attributes": {
+        "include_common_fields": true
+      }
+    },
+    "CreateWorkItem": {
+      "event": {
+        "type": "WorkItem",
+        "action_name": "opened"
+      },
+      "attributes": {
+        "include_common_fields": true
+      }
+    },
+    "CloseWorkItem": {
+      "event": {
+        "type": "WorkItem",
+        "action_name": "closed"
+      },
+      "attributes": {
+        "include_common_fields": true
+      }
+    },
+    "CreateProject": {
+      "event": {
+        "action_name": "created"
+      },
+      "attributes": {
+        "include_common_fields": true
+      }
+    },
+    "UnknownAction": {
+      "event": {
+        "type": "*"
+      },
+      "attributes": {
+        "include_common_fields": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
> Details of the mapping can be found in the associated [wiki](https://github.com/MrRose765/GitLab-Bot-identification/wiki/glmap)

## API management
Before that, the API was managed manually for GitHub. With this PR, it used with an object `APIManager` which is extended for GitHub (`GitHubManager`) or GitLab (`GitLabManager`)